### PR TITLE
Enhance custom attention mode

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -227,6 +227,113 @@
   line-height: 1.4;
 }
 
+.head-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.head-intro {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.head-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.head-card {
+  border-radius: 18px;
+  border: 1px solid rgba(129, 140, 248, 0.3);
+  background: linear-gradient(135deg, rgba(224, 231, 255, 0.55), rgba(219, 234, 254, 0.55));
+  padding: 1.1rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+}
+
+.head-card header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.head-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #312e81;
+}
+
+.head-card p {
+  margin: 0;
+  color: #4c1d95;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.head-card ol {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  color: #1f2937;
+  font-size: 0.95rem;
+}
+
+.custom-builder {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.custom-label {
+  font-weight: 600;
+  color: #312e81;
+}
+
+.custom-textarea {
+  border-radius: 18px;
+  border: 1px solid rgba(99, 102, 241, 0.2);
+  padding: 1rem 1.1rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  background: rgba(248, 250, 252, 0.85);
+  resize: vertical;
+  min-height: 120px;
+  color: #0f172a;
+}
+
+.custom-textarea:focus {
+  outline: none;
+  border-color: rgba(79, 70, 229, 0.6);
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.12);
+}
+
+.custom-hint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #475569;
+  line-height: 1.5;
+}
+
+.custom-empty {
+  margin: 0;
+  font-weight: 600;
+  color: #7c3aed;
+}
+
+.custom-intro {
+  margin-top: -0.5rem;
+  margin-bottom: 1rem;
+  color: #475569;
+  line-height: 1.5;
+}
+
 .attention-cards {
   display: grid;
   gap: 1rem;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -143,7 +143,7 @@ const FALLBACK_CACHE = new Map()
 
 const clamp01 = (value) => Math.min(1, Math.max(0, value))
 
-const tokenKey = (token) => token.toLowerCase().replace(/[^a-z]/g, '')
+const tokenKey = (token) => token.toLowerCase().replace(/[^a-zа-яё0-9-]/gi, '')
 
 const getWordData = (token) => {
   const key = tokenKey(token)
@@ -207,6 +207,268 @@ const computeAttention = (tokens, queryIndex, temperature) => {
   }
 }
 
+const splitIntoTokens = (text) => {
+  if (!text.trim()) {
+    return []
+  }
+
+  const matches = text
+    .normalize('NFC')
+    .match(/(?:\p{L}+[\p{M}]*|\p{N}+|[^\s\p{L}\p{N}]+)/gu)
+
+  return matches ? matches.map((token) => token.trim()).filter(Boolean) : []
+}
+
+const HEAD_DIMENSION = 8
+
+const CUSTOM_HEADS = [
+  {
+    id: 'shape',
+    name: 'Голова формы',
+    description: 'Чувствует длину слова и его окончания.',
+    seed: 11,
+  },
+  {
+    id: 'sound',
+    name: 'Голова звучания',
+    description: 'Сравнивает похожие звуки и рифмы.',
+    seed: 19,
+  },
+  {
+    id: 'meaning',
+    name: 'Голова смысла',
+    description: 'Следит за тематикой и ролями в предложении.',
+    seed: 29,
+  },
+  {
+    id: 'motion',
+    name: 'Голова действия',
+    description: 'Ищет глаголы и направление движения.',
+    seed: 37,
+  },
+]
+
+const createMatrix = (seed, bias) => {
+  return Array.from({ length: HEAD_DIMENSION }, (_, row) =>
+    Array.from({ length: HEAD_DIMENSION }, (_, column) => {
+      const angle = seed * (row + 1) * (column + 1) * 0.17
+      const swirl = Math.sin(angle) * 0.6 + Math.cos(seed * (row + column + 1) * 0.11) * 0.4
+      const diagonalBoost = row === column ? bias : 0
+      return swirl * 0.6 + diagonalBoost
+    }),
+  )
+}
+
+const HEAD_MATRICES = CUSTOM_HEADS.map((head) => ({
+  query: createMatrix(head.seed, 0.4),
+  key: createMatrix(head.seed + 7, 0.3),
+  value: createMatrix(head.seed + 13, 0.5),
+}))
+
+const multiplyMatrixVector = (matrix, vector) =>
+  matrix.map((row) => row.reduce((sum, weight, index) => sum + weight * vector[index], 0))
+
+const normaliseVector = (vector) => {
+  const norm = Math.sqrt(vector.reduce((acc, value) => acc + value * value, 0))
+  if (!Number.isFinite(norm) || norm === 0) {
+    return Array(vector.length).fill(0)
+  }
+
+  return vector.map((value) => value / norm)
+}
+
+const softmaxWithTemperature = (scores, temperature) => {
+  const safeTemperature = Math.max(temperature, 0.05)
+  const scaled = scores.map((score) => score / safeTemperature)
+  const maxScore = Math.max(...scaled)
+  const exps = scaled.map((score) => Math.exp(score - maxScore))
+  const sumExp = exps.reduce((acc, value) => acc + value, 0) || 1
+  return exps.map((value) => value / sumExp)
+}
+
+const letterRegex = /\p{L}/u
+const vowelRegex = /[аеёиоуыэюяaeiouy]/iu
+const cyrillicRegex = /[а-яё]/i
+const latinRegex = /[a-z]/i
+
+const featureVectorForToken = (token) => {
+  const normalized = token.normalize('NFC')
+  const lower = normalized.toLowerCase()
+  const characters = Array.from(lower)
+  const features = Array(HEAD_DIMENSION).fill(0)
+
+  if (!characters.length) {
+    features[0] = 1
+    return features
+  }
+
+  let vowelCount = 0
+  let letterCount = 0
+  let cyrillicCount = 0
+  let latinCount = 0
+
+  characters.forEach((char, index) => {
+    const code = char.codePointAt(0) ?? 0
+    const bucket = index % HEAD_DIMENSION
+    const mirrorBucket = (HEAD_DIMENSION - 1 - bucket + index) % HEAD_DIMENSION
+    features[bucket] += (Math.sin(code * 0.017 * (index + 1)) + 1.2) * 0.5
+    features[mirrorBucket] += (Math.cos(code * 0.011 * (index + 2)) + 1.3) * 0.4
+
+    if (letterRegex.test(char)) {
+      letterCount += 1
+      if (vowelRegex.test(char)) {
+        vowelCount += 1
+      }
+      if (cyrillicRegex.test(char)) {
+        cyrillicCount += 1
+      }
+      if (latinRegex.test(char)) {
+        latinCount += 1
+      }
+    }
+  })
+
+  const consonantCount = Math.max(letterCount - vowelCount, 0)
+
+  features[0] += characters.length / 6
+  features[1] += vowelCount / Math.max(letterCount, 1)
+  features[2] += consonantCount / Math.max(letterCount, 1)
+  features[3] += cyrillicCount > 0 ? 1 : 0
+  features[4] += latinCount > 0 ? 1 : 0
+  features[5] += /\d/u.test(lower) ? 1 : 0
+  features[6] += /[.,!?;:…]/u.test(normalized) ? 1 : 0
+  features[7] += lower.endsWith('ть') || lower.endsWith('ing') ? 1 : 0
+
+  return normaliseVector(features)
+}
+
+const describeDynamicRole = (token, index, tokens) => {
+  const lower = token.toLowerCase()
+
+  if (/^[.,!?;:…]+$/.test(lower)) {
+    return 'Связывает части предложения'
+  }
+
+  if (/^\d+[.,]?\d*$/.test(lower)) {
+    return 'Число добавляет конкретику'
+  }
+
+  if (['и', 'and', 'но', 'а', 'или', 'or'].includes(lower)) {
+    return 'Соединяет идеи между собой'
+  }
+
+  if (/[а-яё]/i.test(token) && token[0] === token[0].toUpperCase() && token.length > 1) {
+    return 'Возможный герой или имя'
+  }
+
+  if (/(ся|сь|ing|ed|ть|ла|ли)$/.test(lower)) {
+    return 'Показывает действие или процесс'
+  }
+
+  if (/(ый|ая|ое|ий|ие|ly|но)$/.test(lower)) {
+    return 'Определяет признак предмета'
+  }
+
+  if (index === 0) {
+    return 'Задаёт тему предложения'
+  }
+
+  if (index === tokens.length - 1) {
+    return 'Подводит итог мысли'
+  }
+
+  return 'Дополняет общий контекст'
+}
+
+const computeCustomAttention = (tokens, queryIndex, temperature) => {
+  if (!tokens.length) {
+    return {
+      weights: [],
+      rawScores: [],
+      contextColor: toColor([0.85, 0.9, 0.95]),
+      info: [],
+      headDetails: CUSTOM_HEADS.map((head) => ({ ...head, weights: [], top: [] })),
+    }
+  }
+
+  const features = tokens.map((token) => featureVectorForToken(token))
+  const projections = features.map((feature) =>
+    HEAD_MATRICES.map((matrices) => ({
+      query: normaliseVector(multiplyMatrixVector(matrices.query, feature)),
+      key: normaliseVector(multiplyMatrixVector(matrices.key, feature)),
+      value: normaliseVector(multiplyMatrixVector(matrices.value, feature)),
+    })),
+  )
+
+  const headScores = CUSTOM_HEADS.map(() => new Array(tokens.length).fill(0))
+  const headWeights = CUSTOM_HEADS.map(() => new Array(tokens.length).fill(0))
+
+  CUSTOM_HEADS.forEach((_, headIndex) => {
+    const queryVector = projections[queryIndex]?.[headIndex]?.query ?? Array(HEAD_DIMENSION).fill(1 / HEAD_DIMENSION)
+    const scores = tokens.map((_, tokenIndex) => {
+      const keyVector = projections[tokenIndex]?.[headIndex]?.key ?? Array(HEAD_DIMENSION).fill(0)
+      return dot(queryVector, keyVector) / Math.sqrt(HEAD_DIMENSION)
+    })
+
+    headScores[headIndex] = scores
+    headWeights[headIndex] = softmaxWithTemperature(scores, temperature)
+  })
+
+  const weights = tokens.map((_, tokenIndex) =>
+    headWeights.reduce((acc, arr) => acc + (arr[tokenIndex] ?? 0), 0) / (headWeights.length || 1),
+  )
+
+  const rawScores = tokens.map((_, tokenIndex) =>
+    headScores.reduce((acc, arr) => acc + (arr[tokenIndex] ?? 0), 0) / (headScores.length || 1),
+  )
+
+  const contextAccumulator = Array(HEAD_DIMENSION).fill(0)
+
+  tokens.forEach((_, tokenIndex) => {
+    CUSTOM_HEADS.forEach((_, headIndex) => {
+      const weight = headWeights[headIndex][tokenIndex] ?? 0
+      const valueVector = projections[tokenIndex]?.[headIndex]?.value ?? Array(HEAD_DIMENSION).fill(0)
+
+      valueVector.forEach((value, dimension) => {
+        contextAccumulator[dimension] += value * weight
+      })
+    })
+  })
+
+  const contextVector = normaliseVector(contextAccumulator)
+  const colorBase = [contextVector[0], contextVector[3], contextVector[6] ?? contextVector[1] ?? 0]
+  const colorVector = colorBase.map((value) => clamp01(0.5 + value / 2))
+  const contextColor = toColor(colorVector)
+
+  const info = tokens.map((token, index) => ({
+    role: describeDynamicRole(token, index, tokens),
+  }))
+
+  const headDetails = CUSTOM_HEADS.map((head, headIndex) => {
+    const weightsForHead = headWeights[headIndex]
+    const top = tokens
+      .map((token, tokenIndex) => ({ token, index: tokenIndex, weight: weightsForHead[tokenIndex] ?? 0 }))
+      .sort((a, b) => b.weight - a.weight)
+      .slice(0, 3)
+
+    return {
+      id: head.id,
+      name: head.name,
+      description: head.description,
+      weights: weightsForHead,
+      top,
+    }
+  })
+
+  return {
+    weights,
+    rawScores,
+    contextColor,
+    info,
+    headDetails,
+  }
+}
+
 const formatPercent = (value) => `${Math.round(value * 1000) / 10}%`
 
 function App() {
@@ -220,6 +482,11 @@ function App() {
   const [gameAttempts, setGameAttempts] = useState(0)
   const [gameRound, setGameRound] = useState(1)
   const [gameFeedback, setGameFeedback] = useState(null)
+  const [customSentence, setCustomSentence] = useState(
+    'Curious minds invent playful robots together',
+  )
+  const [customQueryIndex, setCustomQueryIndex] = useState(0)
+  const [customTemperature, setCustomTemperature] = useState(1)
 
   const activeExample = useMemo(
     () => EXAMPLES.find((example) => example.id === exampleId) ?? EXAMPLES[0],
@@ -227,6 +494,8 @@ function App() {
   )
 
   const tokens = useMemo(() => activeExample.sentence.split(' '), [activeExample.sentence])
+
+  const customTokens = useMemo(() => splitIntoTokens(customSentence), [customSentence])
 
   const gameExample = useMemo(
     () => EXAMPLES.find((example) => example.id === gameExampleId) ?? EXAMPLES[0],
@@ -238,6 +507,16 @@ function App() {
   useEffect(() => {
     setQueryIndex(0)
   }, [activeExample])
+
+  useEffect(() => {
+    setCustomQueryIndex((previous) => {
+      if (!customTokens.length) {
+        return 0
+      }
+
+      return Math.min(previous, customTokens.length - 1)
+    })
+  }, [customTokens])
 
   const { weights, rawScores, contextColor, info } = useMemo(
     () => computeAttention(tokens, queryIndex, temperature),
@@ -277,6 +556,45 @@ function App() {
   }, [gameAttention.weights, gameQueryIndex, gameTokens.length])
 
   const bestSupportWord = gameTokens[bestSupportIndex] ?? '...'
+
+  const customAttention = useMemo(() => {
+    if (!customTokens.length) {
+      return {
+        weights: [],
+        rawScores: [],
+        contextColor: toColor([0.85, 0.9, 0.95]),
+        info: [],
+        headDetails: CUSTOM_HEADS.map((head) => ({
+          id: head.id,
+          name: head.name,
+          description: head.description,
+          weights: [],
+          top: [],
+        })),
+      }
+    }
+
+    return computeCustomAttention(customTokens, customQueryIndex, customTemperature)
+  }, [customTokens, customQueryIndex, customTemperature])
+
+  const {
+    weights: customWeights,
+    rawScores: customRawScores,
+    contextColor: customContextColor,
+    info: customInfo,
+    headDetails: customHeadDetails,
+  } = customAttention
+
+  const customTopInfluences = useMemo(() => {
+    if (!customTokens.length) {
+      return []
+    }
+
+    return customTokens
+      .map((token, index) => ({ token, index, weight: customWeights[index] }))
+      .sort((a, b) => b.weight - a.weight)
+      .slice(0, 3)
+  }, [customTokens, customWeights])
 
   const initializeGame = useCallback(() => {
     const randomExample = EXAMPLES[Math.floor(Math.random() * EXAMPLES.length)]
@@ -349,8 +667,17 @@ function App() {
           >
             Станьте вниманием
           </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'custom'}
+            className={`view-tab ${mode === 'custom' ? 'active' : ''}`}
+            onClick={() => setMode('custom')}
+          >
+            Придумать свою фразу
+          </button>
         </div>
-        {mode === 'explore' ? (
+        {mode === 'explore' && (
           <>
             <section className="panel">
               <h2>Шаг 1. Выберите историю</h2>
@@ -470,7 +797,8 @@ function App() {
               </ul>
             </section>
           </>
-        ) : (
+        )}
+        {mode === 'game' && (
           <section className="panel game-panel">
             <h2>Станьте механизмом внимания</h2>
             <p className="game-description">
@@ -552,6 +880,155 @@ function App() {
               </p>
             )}
           </section>
+        )}
+        {mode === 'custom' && (
+          <>
+            <section className="panel custom-builder">
+              <h2>Соберите собственное предложение</h2>
+              <label className="custom-label" htmlFor="custom-sentence">
+                Напишите фразу, за которой будет наблюдать модель
+              </label>
+              <textarea
+                id="custom-sentence"
+                className="custom-textarea"
+                value={customSentence}
+                onChange={(event) => setCustomSentence(event.target.value)}
+                rows={3}
+                placeholder="Например: Friendly robots happily teach math tricks"
+              />
+              <p className="custom-hint">
+                Мы автоматически разобьём фразу на отдельные слова и запустим упрощённый многоголовый механизм внимания.
+                Даже незнакомые термины получат синтетические векторы, чтобы вы увидели, как распределится внимание.
+              </p>
+              {!customTokens.length && (
+                <p className="custom-empty">Начните печатать — и слова появятся ниже.</p>
+              )}
+            </section>
+
+            {customTokens.length > 0 && (
+              <>
+                <section className="panel">
+                  <h2>Выберите слово с фонариком</h2>
+                  <p className="custom-intro">
+                    Нажмите на слово, чтобы сделать его запросом. Ползунок помогает регулировать ширину луча внимания.
+                  </p>
+                  <div className="tokens" role="list">
+                    {customTokens.map((token, index) => {
+                      const isSelected = index === customQueryIndex
+                      const contribution = customTopInfluences.find((item) => item.index === index)
+
+                      return (
+                        <button
+                          key={`${token}-${index}-custom`}
+                          type="button"
+                          className={`token ${isSelected ? 'selected' : ''} ${contribution ? 'top' : ''}`}
+                          onClick={() => setCustomQueryIndex(index)}
+                          aria-pressed={isSelected}
+                        >
+                          <span className="token-word">{token}</span>
+                          {contribution && (
+                            <span className="token-weight">{formatPercent(customWeights[index])}</span>
+                          )}
+                          {isSelected && <span className="token-focus">фонарик</span>}
+                        </button>
+                      )
+                    })}
+                  </div>
+
+                  <div className="slider-group">
+                    <label htmlFor="custom-temperature">
+                      Температура внимания: {customTemperature.toFixed(1)}
+                    </label>
+                    <input
+                      id="custom-temperature"
+                      type="range"
+                      min="0.3"
+                      max="2"
+                      step="0.1"
+                      value={customTemperature}
+                      onChange={(event) => setCustomTemperature(Number(event.target.value))}
+                    />
+                    <p className="slider-hint">
+                      Слишком низкая температура делает модель придирчивой, а высокая показывает, как слова делят внимание
+                      почти поровну.
+                    </p>
+                  </div>
+                </section>
+
+                <section className="panel">
+                  <h2>Распределение внимания для вашей фразы</h2>
+                  <div className="attention-cards">
+                    {customTokens.map((token, index) => (
+                      <article key={`${token}-${index}-custom-details`} className="attention-card">
+                        <header>
+                          <span className="card-word">{token}</span>
+                          <span className="card-role">{customInfo[index]?.role}</span>
+                        </header>
+                        <div className="weight-bar">
+                          <div
+                            className="weight-bar-fill"
+                            style={{ width: `${Math.round((customWeights[index] ?? 0) * 100)}%` }}
+                          />
+                        </div>
+                        <dl>
+                          <div className="stat">
+                            <dt>Вес внимания</dt>
+                            <dd>{formatPercent(customWeights[index] ?? 0)}</dd>
+                          </div>
+                          <div className="stat">
+                            <dt>Сырой скоринг</dt>
+                            <dd>{(customRawScores[index] ?? 0).toFixed(2)}</dd>
+                          </div>
+                        </dl>
+                      </article>
+                    ))}
+                  </div>
+
+                  <div className="context-section">
+                    <div className="context-color" style={{ background: customContextColor }} aria-hidden />
+                    <div>
+                      <h3>Что выделила модель</h3>
+                      <p>
+                        Слова смешиваются в общий смысл: яркость цвета показывает вклад значений. Топовые влияния сейчас:
+                      </p>
+                      <ol>
+                        {customTopInfluences.map((item) => (
+                          <li key={`${item.token}-${item.index}-summary`}>
+                            <span className="highlight-word">{item.token}</span> — {formatPercent(item.weight)}
+                          </li>
+                        ))}
+                      </ol>
+                    </div>
+                  </div>
+                </section>
+
+                <section className="panel head-panel">
+                  <h2>Головы внимания делят работу</h2>
+                  <p className="head-intro">
+                    Каждая голова оценивает предложение по-своему: кто-то следит за звучанием, другая — за смыслом. Ниже
+                    показано, какие слова они подсветили сильнее всего.
+                  </p>
+                  <div className="head-grid">
+                    {customHeadDetails.map((head) => (
+                      <article key={head.id} className="head-card">
+                        <header>
+                          <h3>{head.name}</h3>
+                          <p>{head.description}</p>
+                        </header>
+                        <ol>
+                          {head.top.map((item) => (
+                            <li key={`${head.id}-${item.index}`}>
+                              <span className="highlight-word">{item.token}</span> — {formatPercent(item.weight)}
+                            </li>
+                          ))}
+                        </ol>
+                      </article>
+                    ))}
+                  </div>
+                </section>
+              </>
+            )}
+          </>
         )}
       </main>
 


### PR DESCRIPTION
## Summary
- add a third interaction mode that lets visitors input their own sentence and inspect attention weights
- reuse the existing attention visualisations for custom text, including top contributors and context colour
- style the custom input panels with textarea and helper copy for clarity
- replace the synthetic scoring with a multi-head attention engine that supports Russian tokens and per-head explanations
- ensure the custom mode renders without the game view and highlight head contributions in the UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e66f333de88327bc01f92d324176c7