### PR TITLE
Fix GitHub Pages base path configuration

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,10 +3,10 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 const repository = process.env.GITHUB_REPOSITORY
-const base = repository ? `/${repository.split('/')[1]}/` : '/'
+const repoName = repository?.split('/')?.[1] ?? 'ai-attention'
 
 // https://vite.dev/config/
-export default defineConfig({
-  base,
+export default defineConfig(({ command }) => ({
+  base: command === 'serve' ? '/' : `/${repoName}/`,
   plugins: [react()],
-})
+}))


### PR DESCRIPTION
## Summary
- ensure the Vite build uses the repository name as the base path when targeting GitHub Pages
- keep the local development server on the root path for unchanged dev experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e678f4fcf48327a92aa5b91ee277ad